### PR TITLE
add audio capture, add no-deps build

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,5 +19,7 @@ jobs:
       run: cargo build --verbose
     - name: Test
       run: cargo test --verbose
+    - name: Test (All Features)
+      run: cargo test --all-features --verbose
     - name: Lint
-      run: cargo clippy
+      run: cargo clippy --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,7 @@ name = "magewell-capture"
 version = "0.0.0"
 dependencies = [
  "bindgen",
+ "bitflags",
  "cc",
  "nix",
  "snafu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,14 @@ build = "build.rs"
 [features]
 default = []
 
-# If no-deps is enabled, the build will be stripped down to avoid any dependency on v4l2, udev, or asound.
-no-deps = []
+# If dep-stubs is enabled, the build will avoid any dependency on v4l2, udev,
+# or asound by building in non-functional stubs.
+dep-stubs = []
 
 [dependencies]
 snafu = "0.8.0"
 nix = { version = "0.28", features = ["event"] }
+bitflags = "2.5.0"
 
 [build-dependencies]
 # We're very permissive here with bindgen due to https://github.com/rust-lang/cargo/issues/5237

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,12 @@ version = "0.0.0"
 edition = "2021"
 build = "build.rs"
 
+[features]
+default = []
+
+# If no-deps is enabled, the build will be stripped down to avoid any dependency on v4l2, udev, or asound.
+no-deps = []
+
 [dependencies]
 snafu = "0.8.0"
 nix = { version = "0.28", features = ["event"] }

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ The default build of this crate requires the following libraries to be installed
 - asound
 - v4l2
 
-Alternatively, you can enable the `no-deps` feature to compile non-functional stub versions of these dependencies into the library. This results in a binary that has no additional runtime dependencies on shared libraries, but will not be able to perform certain functions such as interact with USB devices.
+Alternatively, you can enable the `dep-stubs` feature to compile non-functional stub versions of these dependencies into the library. This results in a binary that has no additional runtime dependencies on shared libraries, but will not be able to perform certain functions such as interact with USB devices.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ This is a Rust crate for interacting with Magewell capture cards. It is a wrappe
 
 ## Dependencies
 
-To build this crate, you'll need the following libraries installed:
+The default build of this crate requires the following libraries to be installed:
 
 - udev
 - asound
 - v4l2
+
+Alternatively, you can enable the `no-deps` feature to compile non-functional stub versions of these dependencies into the library. This results in a binary that has no additional runtime dependencies on shared libraries, but will not be able to perform certain functions such as interact with USB devices.

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,7 @@
 extern crate bindgen;
 extern crate cc;
 
-use std::{env, path::PathBuf};
+use std::{env, fs, path::PathBuf, process::Command};
 
 const SDK_PATH: &str = "vendor/Magewell_Capture_SDK_Linux_3.3.1.1313";
 
@@ -23,13 +23,40 @@ fn main() {
         }
     );
 
-    println!("cargo:rustc-link-search={}", vendor_lib_path);
+    let lib_path = out_path.join("lib");
+    fs::create_dir_all(&lib_path).unwrap();
+    fs::copy(
+        format!("{}/libMWCapture.a", vendor_lib_path),
+        lib_path.join("libMWCapture.a"),
+    )
+    .unwrap();
+
+    println!("cargo:rustc-link-search={}", lib_path.display());
     println!("cargo:rustc-link-lib=static=MWCapture");
 
     println!("cargo:rustc-link-lib=stdc++");
-    println!("cargo:rustc-link-lib=v4l2");
-    println!("cargo:rustc-link-lib=asound");
-    println!("cargo:rustc-link-lib=udev");
+
+    if env::var("CARGO_FEATURE_NO_DEPS").is_ok() {
+        // Strip libusb from the build so we can stub it out.
+        Command::new("ar")
+            .args([
+                "d",
+                lib_path.join("libMWCapture.a").to_str().unwrap(),
+                "libusb_1_0_la-linux_udev.o",
+                "libusb_1_0_la-linux_usbfs.o",
+                "libusb_1_0_la-core.o",
+                "libusb_1_0_la-io.o",
+                "libusb_1_0_la-hotplug.o",
+                "libusb_1_0_la-descriptor.o",
+                "libusb_1_0_la-sync.o",
+            ])
+            .status()
+            .expect("failed to remove libudev.a from libMWCapture.a");
+    } else {
+        println!("cargo:rustc-link-lib=v4l2");
+        println!("cargo:rustc-link-lib=asound");
+        println!("cargo:rustc-link-lib=udev");
+    }
 
     cc::Build::new()
         .include(format!("{}/Include", SDK_PATH))
@@ -40,6 +67,7 @@ fn main() {
         .clang_arg(format!("-I{}/Include", SDK_PATH))
         .header("src/lib.hpp")
         .allowlist_function("MW.+")
+        .allowlist_var("MW.+")
         .generate()
         .expect("unable to generate bindings");
 

--- a/build.rs
+++ b/build.rs
@@ -36,7 +36,7 @@ fn main() {
 
     println!("cargo:rustc-link-lib=stdc++");
 
-    if env::var("CARGO_FEATURE_NO_DEPS").is_ok() {
+    if env::var("CARGO_FEATURE_DEP_STUBS").is_ok() {
         // Strip libusb from the build so we can stub it out.
         Command::new("ar")
             .args([

--- a/src/dep_stubs.rs
+++ b/src/dep_stubs.rs
@@ -25,39 +25,29 @@ macro_rules! return_expr {
 // Creates a stub that always returns null.
 macro_rules! return_null {
     ($name:ident) => {
-        #[no_mangle]
-        pub extern "C" fn $name() -> *mut std::ffi::c_void {
-            // Want to see when this is called? Uncomment the following line.
-            //println!("{} called", stringify!($name));
-            std::ptr::null_mut()
-        }
+        return_expr!($name, *mut std::ffi::c_void, std::ptr::null_mut());
     };
 }
 
 // Creates a stub with no return value.
 macro_rules! return_void {
     ($name:ident) => {
-        #[no_mangle]
-        pub extern "C" fn $name() {
-            // Want to see when this is called? Uncomment the following line.
-            //println!("{} called", stringify!($name));
-        }
+        return_expr!($name, (), ());
     };
 }
 
 // Creates a stub that always returns a negative system error code.
 macro_rules! return_error {
     ($name:ident) => {
-        #[no_mangle]
-        pub extern "C" fn $name() -> std::ffi::c_int {
-            // Want to see when this is called? Uncomment the following line.
-            //println!("{} called", stringify!($name));
-            -(nix::errno::Errno::ENOENT as std::ffi::c_int)
-        }
+        return_expr!(
+            $name,
+            std::ffi::c_int,
+            -(nix::errno::Errno::ENOSYS as std::ffi::c_int)
+        );
     };
 }
 
-mod no_v4l2 {
+mod v4l2_stubs {
     use std::ffi::c_void;
 
     return_error!(v4l2_open);
@@ -67,7 +57,7 @@ mod no_v4l2 {
     return_error!(v4l2_munmap);
 }
 
-mod no_udev {
+mod udev_stubs {
     return_null!(udev_new);
     return_null!(udev_unref);
     return_null!(udev_enumerate_new);
@@ -93,7 +83,7 @@ mod no_udev {
     return_error!(udev_monitor_filter_add_match_subsystem_devtype);
 }
 
-mod no_usb {
+mod usb_stubs {
     use std::ffi::c_int;
 
     const NOT_SUPPORTED: c_int = 12;
@@ -119,7 +109,7 @@ mod no_usb {
     return_expr!(libusb_release_interface, c_int, NOT_SUPPORTED);
 }
 
-mod no_asound {
+mod asound_stubs {
     use std::ffi::{c_int, c_long};
 
     return_error!(snd_card_next);

--- a/src/eco_channel.rs
+++ b/src/eco_channel.rs
@@ -1,6 +1,6 @@
 use super::{
     sys, ChannelHandle, ChannelInfo, EcoVideoCaptureFrame, EcoVideoCaptureStatus, FourCC,
-    ProEcoCaptureFamily, Result, UniversalCaptureFamily,
+    ProEcoCaptureFamilyChannel, Result, UniversalCaptureFamilyChannel,
 };
 use nix::sys::eventfd::EventFd;
 use snafu::prelude::*;
@@ -14,7 +14,7 @@ pub struct EcoChannel {
     video_capture_frame: Option<Pin<Box<EcoVideoCaptureFrame>>>,
 }
 
-impl UniversalCaptureFamily for EcoChannel {
+unsafe impl UniversalCaptureFamilyChannel for EcoChannel {
     fn handle(&self) -> *mut c_void {
         *self.handle
     }
@@ -24,7 +24,7 @@ impl UniversalCaptureFamily for EcoChannel {
     }
 }
 
-impl ProEcoCaptureFamily for EcoChannel {
+unsafe impl ProEcoCaptureFamilyChannel for EcoChannel {
     fn event(&self) -> sys::MWCAP_PTR {
         self.event_fd.as_raw_fd() as _
     }

--- a/src/eco_channel.rs
+++ b/src/eco_channel.rs
@@ -1,0 +1,125 @@
+use super::{
+    sys, ChannelHandle, ChannelInfo, EcoVideoCaptureFrame, EcoVideoCaptureStatus, FourCC,
+    ProEcoCaptureFamily, Result, UniversalCaptureFamily,
+};
+use nix::sys::eventfd::EventFd;
+use snafu::prelude::*;
+use std::{boxed::Box, ffi::c_void, mem::MaybeUninit, os::fd::AsRawFd, pin::Pin};
+
+pub struct EcoChannel {
+    handle: ChannelHandle,
+    info: ChannelInfo,
+    event_fd: EventFd,
+    // hold onto a reference of the currently set capture frame
+    video_capture_frame: Option<Pin<Box<EcoVideoCaptureFrame>>>,
+}
+
+impl UniversalCaptureFamily for EcoChannel {
+    fn handle(&self) -> *mut c_void {
+        *self.handle
+    }
+
+    fn info(&self) -> &ChannelInfo {
+        &self.info
+    }
+}
+
+impl ProEcoCaptureFamily for EcoChannel {
+    fn event(&self) -> sys::MWCAP_PTR {
+        self.event_fd.as_raw_fd() as _
+    }
+}
+
+impl EcoChannel {
+    pub(crate) fn new(handle: ChannelHandle, info: ChannelInfo) -> Result<Self> {
+        let event_fd = EventFd::new().whatever_context("unable to create eventfd")?;
+        Ok(Self {
+            handle,
+            info,
+            event_fd,
+            video_capture_frame: None,
+        })
+    }
+
+    pub fn start_video_capture(&mut self, width: u16, height: u16, format: FourCC) -> Result<()> {
+        let mut params = sys::_MWCAP_VIDEO_ECO_CAPTURE_OPEN {
+            cx: width as _,
+            cy: height as _,
+            dwFOURCC: format.as_u32(),
+            llFrameDuration: -1,
+            hEvent: self.event_fd.as_raw_fd() as _,
+        };
+        unsafe {
+            if sys::MWStartVideoEcoCapture(self.handle(), &mut params as *mut _)
+                != sys::_MW_RESULT__MW_SUCCEEDED
+            {
+                whatever!("unable to start video capture");
+            }
+        }
+        Ok(())
+    }
+
+    pub fn stop_video_capture(&mut self) -> Result<()> {
+        unsafe {
+            if sys::MWStopVideoEcoCapture(self.handle()) != sys::_MW_RESULT__MW_SUCCEEDED {
+                whatever!("unable to stop video capture");
+            }
+        }
+        Ok(())
+    }
+
+    pub fn set_video_capture_frame(&mut self, frame: EcoVideoCaptureFrame) -> Result<()> {
+        if self.video_capture_frame.is_some() {
+            whatever!("video frame already set");
+        }
+        let mut frame = Box::pin(frame);
+        unsafe {
+            if sys::MWCaptureSetVideoEcoFrame(self.handle(), frame.as_mut_ptr())
+                != sys::_MW_RESULT__MW_SUCCEEDED
+            {
+                whatever!("unable to set video frame");
+            }
+        }
+        self.video_capture_frame = Some(frame);
+        Ok(())
+    }
+
+    /// Returns the next video capture frame, if available. If no frame is available, returns
+    /// `None`. Invoke `wait` to block until a frame may be available.
+    pub fn get_video_capture_status(&mut self) -> Result<Option<EcoVideoCaptureStatus>> {
+        let status = unsafe {
+            let mut status = MaybeUninit::uninit();
+            if sys::MWGetVideoEcoCaptureStatus(self.handle(), status.as_mut_ptr())
+                != sys::_MW_RESULT__MW_SUCCEEDED
+            {
+                whatever!("unable to get video capture status");
+            }
+            status.assume_init()
+        };
+        if status.pvFrame == 0 {
+            return Ok(None);
+        }
+        Ok(Some(EcoVideoCaptureStatus::new(
+            *Pin::into_inner(
+                self.video_capture_frame
+                    .take()
+                    .whatever_context("no video frame set")?,
+            ),
+            status,
+        )))
+    }
+
+    /// Blocks until the next video frame is available or until an event registered via
+    /// `register_notify`.
+    pub fn wait(&self) -> Result<()> {
+        if self
+            .event_fd
+            .read()
+            .whatever_context("unable to read eventfd")?
+            == 0
+        {
+            whatever!("error event received");
+        }
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,8 +243,12 @@ mod tests {
                 Channel::Eco(ch) => {
                     for _ in 0..5 {
                         ch.wait().unwrap();
-                        assert!(ch.capture_audio_frame(&mut audio_frame).unwrap());
-                        assert!(audio_frame.timestamp() > start_time);
+                        let mut count = 0;
+                        while ch.capture_audio_frame(&mut audio_frame).unwrap() {
+                            count += 1;
+                            assert!(audio_frame.timestamp() > start_time);
+                        }
+                        assert!(count > 0);
                     }
                 }
                 _ => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,8 @@ pub mod sys {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 
-#[cfg(feature = "no-deps")]
-mod no_deps;
+#[cfg(feature = "dep-stubs")]
+mod dep_stubs;
 
 mod fourcc;
 pub use fourcc::*;
@@ -156,7 +156,7 @@ impl Channel {
     }
 }
 
-impl UniversalCaptureFamily for Channel {
+unsafe impl UniversalCaptureFamilyChannel for Channel {
     fn handle(&self) -> *mut c_void {
         match self {
             Channel::Eco(ch) => ch.handle(),
@@ -172,7 +172,7 @@ impl UniversalCaptureFamily for Channel {
     }
 }
 
-impl ProEcoCaptureFamily for Channel {
+unsafe impl ProEcoCaptureFamilyChannel for Channel {
     fn event(&self) -> sys::MWCAP_PTR {
         match self {
             Channel::Eco(ch) => ch.event(),
@@ -236,7 +236,7 @@ mod tests {
         {
             ch.start_audio_capture().unwrap();
             let notify_handle = ch
-                .register_notify(sys::MWCAP_NOTIFY_AUDIO_FRAME_BUFFERED)
+                .register_notify(NotifyEvents::AUDIO_FRAME_BUFFERED)
                 .unwrap();
 
             match &mut ch {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,9 @@
-use nix::sys::eventfd::EventFd;
 use snafu::prelude::*;
 use std::{
     mem::MaybeUninit,
     ops::Deref,
-    os::{
-        fd::AsRawFd,
-        raw::{c_longlong, c_void},
-    },
-    pin::Pin,
+    os::raw::c_void,
     sync::{Mutex, OnceLock},
-    time::Duration,
 };
 
 pub mod sys {
@@ -23,8 +17,23 @@ pub mod sys {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 
+#[cfg(feature = "no-deps")]
+mod no_deps;
+
 mod fourcc;
 pub use fourcc::*;
+
+mod eco_channel;
+pub use eco_channel::*;
+
+mod pro_channel;
+pub use pro_channel::*;
+
+mod universal_capture_family;
+pub use universal_capture_family::*;
+
+mod pro_eco_capture_family;
+pub use pro_eco_capture_family::*;
 
 // Contains simple wrappers around the Magewell SDK types.
 mod types;
@@ -140,48 +149,10 @@ impl Channel {
         };
 
         Ok(if info.family_name().to_str() == Ok("Eco Capture") {
-            let event_fd = EventFd::new().whatever_context("unable to create eventfd")?;
-            Channel::Eco(EcoChannel {
-                handle,
-                info,
-                event_fd,
-                video_capture_frame: None,
-            })
+            Channel::Eco(EcoChannel::new(handle, info)?)
         } else {
-            Channel::Pro(ProChannel { handle, info })
+            Channel::Pro(ProChannel::new(handle, info)?)
         })
-    }
-}
-
-pub trait UniversalCaptureFamily {
-    fn handle(&self) -> *mut c_void;
-
-    fn info(&self) -> &ChannelInfo;
-
-    fn get_video_signal_status(&self) -> Result<VideoSignalStatus> {
-        let mut status = MaybeUninit::uninit();
-        unsafe {
-            if sys::MWGetVideoSignalStatus(self.handle(), status.as_mut_ptr())
-                != sys::_MW_RESULT__MW_SUCCEEDED
-            {
-                whatever!("unable to get video signal status");
-            }
-            Ok(status.assume_init().into())
-        }
-    }
-}
-
-pub trait ProEcoCaptureFamily: UniversalCaptureFamily {
-    fn get_device_time(&self) -> Result<Duration> {
-        let mut time: c_longlong = 0;
-        unsafe {
-            if sys::MWGetDeviceTime(self.handle(), &mut time as *mut _)
-                != sys::_MW_RESULT__MW_SUCCEEDED
-            {
-                whatever!("unable to get device time");
-            }
-            Ok(Duration::from_nanos(100 * time as u64))
-        }
     }
 }
 
@@ -201,119 +172,14 @@ impl UniversalCaptureFamily for Channel {
     }
 }
 
-pub struct EcoChannel {
-    handle: ChannelHandle,
-    info: ChannelInfo,
-    event_fd: EventFd,
-    // hold onto a reference of the currently set capture frame
-    video_capture_frame: Option<Pin<Box<EcoVideoCaptureFrame>>>,
-}
-
-impl UniversalCaptureFamily for EcoChannel {
-    fn handle(&self) -> *mut c_void {
-        *self.handle
-    }
-
-    fn info(&self) -> &ChannelInfo {
-        &self.info
+impl ProEcoCaptureFamily for Channel {
+    fn event(&self) -> sys::MWCAP_PTR {
+        match self {
+            Channel::Eco(ch) => ch.event(),
+            Channel::Pro(ch) => ch.event(),
+        }
     }
 }
-
-impl ProEcoCaptureFamily for EcoChannel {}
-
-impl EcoChannel {
-    pub fn start_video_capture(&mut self, width: u16, height: u16, format: FourCC) -> Result<()> {
-        let mut params = sys::_MWCAP_VIDEO_ECO_CAPTURE_OPEN {
-            cx: width as _,
-            cy: height as _,
-            dwFOURCC: format.as_u32(),
-            llFrameDuration: -1,
-            hEvent: self.event_fd.as_raw_fd() as _,
-        };
-        unsafe {
-            if sys::MWStartVideoEcoCapture(self.handle(), &mut params as *mut _)
-                != sys::_MW_RESULT__MW_SUCCEEDED
-            {
-                whatever!("unable to start video capture");
-            }
-        }
-        Ok(())
-    }
-
-    pub fn stop_video_capture(&mut self) -> Result<()> {
-        unsafe {
-            if sys::MWStopVideoEcoCapture(self.handle()) != sys::_MW_RESULT__MW_SUCCEEDED {
-                whatever!("unable to stop video capture");
-            }
-        }
-        Ok(())
-    }
-
-    pub fn set_video_capture_frame(&mut self, frame: EcoVideoCaptureFrame) -> Result<()> {
-        if self.video_capture_frame.is_some() {
-            whatever!("video frame already set");
-        }
-        let mut frame = Box::pin(frame);
-        unsafe {
-            if sys::MWCaptureSetVideoEcoFrame(self.handle(), frame.as_mut_ptr())
-                != sys::_MW_RESULT__MW_SUCCEEDED
-            {
-                whatever!("unable to set video frame");
-            }
-        }
-        self.video_capture_frame = Some(frame);
-        Ok(())
-    }
-
-    pub fn get_video_capture_status(&mut self) -> Result<EcoVideoCaptureStatus> {
-        let status = unsafe {
-            let mut status = MaybeUninit::uninit();
-            if sys::MWGetVideoEcoCaptureStatus(self.handle(), status.as_mut_ptr())
-                != sys::_MW_RESULT__MW_SUCCEEDED
-            {
-                whatever!("unable to get video capture status");
-            }
-            status.assume_init()
-        };
-        Ok(EcoVideoCaptureStatus::new(
-            *Pin::into_inner(
-                self.video_capture_frame
-                    .take()
-                    .whatever_context("no video frame set")?,
-            ),
-            status,
-        ))
-    }
-
-    pub fn wait(&self) -> Result<()> {
-        if self
-            .event_fd
-            .read()
-            .whatever_context("unable to read eventfd")?
-            == 0
-        {
-            whatever!("error event received");
-        }
-        Ok(())
-    }
-}
-
-pub struct ProChannel {
-    handle: ChannelHandle,
-    info: ChannelInfo,
-}
-
-impl UniversalCaptureFamily for ProChannel {
-    fn handle(&self) -> *mut c_void {
-        *self.handle
-    }
-
-    fn info(&self) -> &ChannelInfo {
-        &self.info
-    }
-}
-
-impl ProEcoCaptureFamily for ProChannel {}
 
 // Theses tests will pass if there are no devices present, but to really get their full value, an
 // Eco device should be present and channel 0:0 should be connected to a video source.
@@ -344,7 +210,17 @@ mod tests {
             return;
         }
 
-        let ch = Channel::open(0, 0).unwrap();
+        let mut ch = Channel::open(0, 0).unwrap();
+
+        let start_time = ch.get_device_time().unwrap();
+
+        let audio_status = ch.get_audio_signal_status().unwrap();
+        println!(
+            "audio channels = {}, bit depth = {}, sample rate = {}",
+            audio_status.channel_count(),
+            audio_status.bits_per_sample(),
+            audio_status.sample_rate(),
+        );
 
         let video_status = ch.get_video_signal_status().unwrap();
         println!(
@@ -355,9 +231,35 @@ mod tests {
             video_status.frame_duration(),
         );
 
+        // Try capturing some audio.
+        let mut audio_frame = AudioCaptureFrame::default();
+        {
+            ch.start_audio_capture().unwrap();
+            let notify_handle = ch
+                .register_notify(sys::MWCAP_NOTIFY_AUDIO_FRAME_BUFFERED)
+                .unwrap();
+
+            match &mut ch {
+                Channel::Eco(ch) => {
+                    for _ in 0..5 {
+                        ch.wait().unwrap();
+                        assert!(ch.capture_audio_frame(&mut audio_frame).unwrap());
+                        assert!(audio_frame.timestamp() > start_time);
+                    }
+                }
+                _ => {
+                    // TODO: support pro devices better?
+                    panic!("expected channel type");
+                }
+            }
+
+            ch.unregister_notify(notify_handle).unwrap();
+            ch.stop_audio_capture().unwrap();
+        }
+
+        // Try capturing some video.
         match ch {
             Channel::Eco(mut ch) => {
-                let start_time = ch.get_device_time().unwrap();
                 let format = FourCC::new('B', 'G', 'R', ' ');
                 let stride = format.min_stride(video_status.image_width(), 4);
                 let image_size = format.image_size(
@@ -377,10 +279,13 @@ mod tests {
 
                 for _ in 0..5 {
                     ch.set_video_capture_frame(frame).unwrap();
-                    ch.wait().unwrap();
-                    let status = ch.get_video_capture_status().unwrap();
-                    assert!(status.timestamp() > start_time);
-                    frame = status.into_frame();
+                    frame = loop {
+                        ch.wait().unwrap();
+                        if let Some(status) = ch.get_video_capture_status().unwrap() {
+                            assert!(status.timestamp() > start_time);
+                            break status.into_frame();
+                        }
+                    }
                 }
 
                 ch.stop_video_capture().unwrap();

--- a/src/no_deps.rs
+++ b/src/no_deps.rs
@@ -1,0 +1,188 @@
+/**
+ *
+ * This module contains stubs for third-party dependencies of the Magewell Capture SDK.
+ * The SDK requires these dependencies to be present in the build. However, none of them are
+ * necessary to perform capture from PCIe devices, so for a more minimal build, we can eliminate
+ * the dependencies by stubbing out the essential symbols of these libraries.
+ *
+ * It is impossible for the vast majority of these stubs to be called, but we make our best effort
+ * to always return a valid value or error code anyway.
+ *
+ */
+
+// Creates a stub with the given return type and constant return value.
+macro_rules! return_expr {
+    ($name:ident, $ret:ty, $val:expr) => {
+        #[no_mangle]
+        pub extern "C" fn $name() -> $ret {
+            // Want to see when this is called? Uncomment the following line.
+            //println!("{} called", stringify!($name));
+            $val
+        }
+    };
+}
+
+// Creates a stub that always returns null.
+macro_rules! return_null {
+    ($name:ident) => {
+        #[no_mangle]
+        pub extern "C" fn $name() -> *mut std::ffi::c_void {
+            // Want to see when this is called? Uncomment the following line.
+            //println!("{} called", stringify!($name));
+            std::ptr::null_mut()
+        }
+    };
+}
+
+// Creates a stub with no return value.
+macro_rules! return_void {
+    ($name:ident) => {
+        #[no_mangle]
+        pub extern "C" fn $name() {
+            // Want to see when this is called? Uncomment the following line.
+            //println!("{} called", stringify!($name));
+        }
+    };
+}
+
+// Creates a stub that always returns a negative system error code.
+macro_rules! return_error {
+    ($name:ident) => {
+        #[no_mangle]
+        pub extern "C" fn $name() -> std::ffi::c_int {
+            // Want to see when this is called? Uncomment the following line.
+            //println!("{} called", stringify!($name));
+            -(nix::errno::Errno::ENOENT as std::ffi::c_int)
+        }
+    };
+}
+
+mod no_v4l2 {
+    use std::ffi::c_void;
+
+    return_error!(v4l2_open);
+    return_error!(v4l2_close);
+    return_error!(v4l2_ioctl);
+    return_expr!(v4l2_mmap, *mut c_void, -1_isize as *mut c_void);
+    return_error!(v4l2_munmap);
+}
+
+mod no_udev {
+    return_null!(udev_new);
+    return_null!(udev_unref);
+    return_null!(udev_enumerate_new);
+    return_null!(udev_enumerate_unref);
+    return_error!(udev_enumerate_add_match_subsystem);
+    return_error!(udev_enumerate_add_match_property);
+    return_error!(udev_enumerate_scan_devices);
+    return_null!(udev_enumerate_get_list_entry);
+    return_null!(udev_list_entry_get_next);
+    return_null!(udev_list_entry_get_name);
+    return_null!(udev_device_new_from_syspath);
+    return_null!(udev_device_unref);
+    return_null!(udev_device_get_devnode);
+    return_null!(udev_device_get_parent_with_subsystem_devtype);
+    return_null!(udev_device_get_sysname);
+    return_null!(udev_device_get_sysattr_value);
+    return_null!(udev_device_get_action);
+    return_null!(udev_monitor_new_from_netlink);
+    return_null!(udev_monitor_unref);
+    return_error!(udev_monitor_enable_receiving);
+    return_null!(udev_monitor_receive_device);
+    return_error!(udev_monitor_get_fd);
+    return_error!(udev_monitor_filter_add_match_subsystem_devtype);
+}
+
+mod no_usb {
+    use std::ffi::c_int;
+
+    const NOT_SUPPORTED: c_int = 12;
+
+    return_expr!(libusb_attach_kernel_driver, c_int, NOT_SUPPORTED);
+    return_expr!(libusb_claim_interface, c_int, NOT_SUPPORTED);
+    return_void!(libusb_close);
+    return_expr!(libusb_control_transfer, c_int, NOT_SUPPORTED);
+    return_expr!(libusb_detach_kernel_driver, c_int, NOT_SUPPORTED);
+    return_void!(libusb_exit);
+    return_void!(libusb_free_device_list);
+    return_expr!(libusb_get_bus_number, u8, 0);
+    return_expr!(libusb_get_device_address, u8, 0);
+    return_expr!(libusb_get_device_descriptor, c_int, NOT_SUPPORTED);
+    return_expr!(libusb_get_device_list, isize, 0);
+    return_expr!(libusb_get_port_number, u8, 0);
+    return_expr!(libusb_get_string_descriptor_ascii, c_int, NOT_SUPPORTED);
+    return_expr!(libusb_handle_events_timeout_completed, c_int, NOT_SUPPORTED);
+    return_expr!(libusb_hotplug_register_callback, c_int, NOT_SUPPORTED);
+    return_expr!(libusb_init, c_int, NOT_SUPPORTED);
+    return_expr!(libusb_kernel_driver_active, c_int, NOT_SUPPORTED);
+    return_expr!(libusb_open, c_int, NOT_SUPPORTED);
+    return_expr!(libusb_release_interface, c_int, NOT_SUPPORTED);
+}
+
+mod no_asound {
+    use std::ffi::{c_int, c_long};
+
+    return_error!(snd_card_next);
+    return_error!(snd_config_update_free_global);
+    return_error!(snd_ctl_card_info);
+    return_null!(snd_ctl_card_info_get_id);
+    return_error!(snd_ctl_card_info_get_name);
+    return_expr!(snd_ctl_card_info_sizeof, usize, 16 /* arbitrary */);
+    return_error!(snd_ctl_close);
+    return_error!(snd_ctl_open);
+    return_error!(snd_mixer_attach);
+    return_error!(snd_mixer_close);
+    return_error!(snd_mixer_detach);
+    return_expr!(snd_mixer_elem_get_type, c_int, 0 /* simple */);
+    return_null!(snd_mixer_elem_next);
+    return_null!(snd_mixer_first_elem);
+    return_error!(snd_mixer_load);
+    return_error!(snd_mixer_open);
+    return_error!(snd_mixer_selem_get_capture_switch);
+    return_error!(snd_mixer_selem_get_capture_volume);
+    return_error!(snd_mixer_selem_get_capture_volume_range);
+    return_null!(snd_mixer_selem_get_name);
+    return_expr!(snd_mixer_selem_has_capture_channel, c_int, 0);
+    return_expr!(snd_mixer_selem_has_capture_volume, c_int, 0);
+    return_expr!(snd_mixer_selem_has_playback_volume, c_int, 0);
+    return_expr!(snd_mixer_selem_is_active, c_int, 0);
+    return_error!(snd_mixer_selem_register);
+    return_error!(snd_mixer_selem_set_capture_dB);
+    return_error!(snd_mixer_selem_set_capture_switch);
+    return_error!(snd_mixer_selem_set_capture_switch_all);
+    return_error!(snd_mixer_selem_set_capture_volume);
+    return_error!(snd_mixer_selem_set_playback_dB);
+    return_error!(snd_mixer_selem_set_playback_switch_all);
+    return_expr!(snd_pcm_avail_update, c_long, -1);
+    return_error!(snd_pcm_close);
+    return_error!(snd_pcm_drain);
+    return_error!(snd_pcm_drop);
+    return_error!(snd_pcm_hw_params);
+    return_error!(snd_pcm_hw_params_any);
+    return_error!(snd_pcm_hw_params_current);
+    return_error!(snd_pcm_hw_params_get_buffer_size);
+    return_error!(snd_pcm_hw_params_get_channels);
+    return_error!(snd_pcm_hw_params_get_period_size);
+    return_error!(snd_pcm_hw_params_get_periods);
+    return_error!(snd_pcm_hw_params_set_access);
+    return_error!(snd_pcm_hw_params_set_channels);
+    return_error!(snd_pcm_hw_params_set_format);
+    return_error!(snd_pcm_hw_params_set_rate_near);
+    return_expr!(snd_pcm_hw_params_sizeof, usize, 16 /* arbitrary */);
+    return_error!(snd_pcm_open);
+    return_error!(snd_pcm_prepare);
+    return_error!(snd_pcm_readi);
+    return_error!(snd_pcm_recover);
+    return_error!(snd_pcm_resume);
+    return_error!(snd_pcm_start);
+    return_expr!(snd_pcm_state, c_int, 8 /* disconnected */);
+    return_error!(snd_pcm_status);
+    return_expr!(snd_pcm_status_get_state, c_int, 8 /* disconnected */);
+    return_expr!(snd_pcm_status_sizeof, usize, 16 /* arbitrary */);
+    return_error!(snd_pcm_sw_params);
+    return_error!(snd_pcm_sw_params_current);
+    return_error!(snd_pcm_sw_params_set_start_threshold);
+    return_error!(snd_pcm_sw_params_set_stop_threshold);
+    return_expr!(snd_pcm_sw_params_sizeof, usize, 16 /* arbitrary */);
+    return_expr!(snd_pcm_writei, c_long, -1);
+}

--- a/src/pro_channel.rs
+++ b/src/pro_channel.rs
@@ -1,4 +1,7 @@
-use super::{sys, ChannelHandle, ChannelInfo, ProEcoCaptureFamily, Result, UniversalCaptureFamily};
+use super::{
+    sys, ChannelHandle, ChannelInfo, ProEcoCaptureFamilyChannel, Result,
+    UniversalCaptureFamilyChannel,
+};
 use snafu::prelude::*;
 use std::ffi::c_void;
 
@@ -28,7 +31,7 @@ impl ProChannel {
     }
 }
 
-impl UniversalCaptureFamily for ProChannel {
+unsafe impl UniversalCaptureFamilyChannel for ProChannel {
     fn handle(&self) -> *mut c_void {
         *self.handle
     }
@@ -38,7 +41,7 @@ impl UniversalCaptureFamily for ProChannel {
     }
 }
 
-impl ProEcoCaptureFamily for ProChannel {
+unsafe impl ProEcoCaptureFamilyChannel for ProChannel {
     fn event(&self) -> sys::MWCAP_PTR {
         self.event
     }

--- a/src/pro_channel.rs
+++ b/src/pro_channel.rs
@@ -1,0 +1,45 @@
+use super::{sys, ChannelHandle, ChannelInfo, ProEcoCaptureFamily, Result, UniversalCaptureFamily};
+use snafu::prelude::*;
+use std::ffi::c_void;
+
+pub struct ProChannel {
+    handle: ChannelHandle,
+    info: ChannelInfo,
+    event: sys::MWCAP_PTR,
+}
+
+impl Drop for ProChannel {
+    fn drop(&mut self) {
+        unsafe { sys::MWCloseEvent(self.event) };
+    }
+}
+
+impl ProChannel {
+    pub(crate) fn new(handle: ChannelHandle, info: ChannelInfo) -> Result<Self> {
+        let event = unsafe { sys::MWCreateEvent() };
+        if event == 0 {
+            whatever!("unable to create event");
+        }
+        Ok(Self {
+            handle,
+            info,
+            event,
+        })
+    }
+}
+
+impl UniversalCaptureFamily for ProChannel {
+    fn handle(&self) -> *mut c_void {
+        *self.handle
+    }
+
+    fn info(&self) -> &ChannelInfo {
+        &self.info
+    }
+}
+
+impl ProEcoCaptureFamily for ProChannel {
+    fn event(&self) -> sys::MWCAP_PTR {
+        self.event
+    }
+}

--- a/src/pro_eco_capture_family.rs
+++ b/src/pro_eco_capture_family.rs
@@ -1,0 +1,74 @@
+use super::{sys, AudioCaptureFrame, Result, UniversalCaptureFamily};
+use snafu::prelude::*;
+use std::{os::raw::c_longlong, time::Duration};
+
+pub trait ProEcoCaptureFamily: UniversalCaptureFamily {
+    fn event(&self) -> sys::MWCAP_PTR;
+
+    fn get_device_time(&self) -> Result<Duration> {
+        let mut time: c_longlong = 0;
+        unsafe {
+            if sys::MWGetDeviceTime(self.handle(), &mut time as *mut _)
+                != sys::_MW_RESULT__MW_SUCCEEDED
+            {
+                whatever!("unable to get device time");
+            }
+            Ok(Duration::from_nanos(100 * time as u64))
+        }
+    }
+
+    /// Causes `wait` to return any time the specified events (e.g.
+    /// `MWCAP_NOTIFY_AUDIO_FRAME_BUFFERED`) occur. Returns a handle that can be used to
+    /// unregister.
+    fn register_notify(&self, events: u32) -> Result<sys::MWCAP_PTR> {
+        Ok(unsafe {
+            let handle = sys::MWRegisterNotify(self.handle(), self.event(), events);
+            if handle == 0 {
+                whatever!("unable to register notify");
+            }
+            handle
+        })
+    }
+
+    fn unregister_notify(&self, handle: sys::MWCAP_PTR) -> Result<()> {
+        unsafe {
+            if sys::MWUnregisterNotify(self.handle(), handle) != sys::_MW_RESULT__MW_SUCCEEDED {
+                whatever!("unable to unregister notify");
+            }
+        }
+        Ok(())
+    }
+
+    fn start_audio_capture(&mut self) -> Result<()> {
+        unsafe {
+            if sys::MWStartAudioCapture(self.handle()) != sys::_MW_RESULT__MW_SUCCEEDED {
+                whatever!("unable to start audio capture");
+            }
+        }
+        Ok(())
+    }
+
+    fn stop_audio_capture(&mut self) -> Result<()> {
+        unsafe {
+            if sys::MWStopAudioCapture(self.handle()) != sys::_MW_RESULT__MW_SUCCEEDED {
+                whatever!("unable to start audio capture");
+            }
+        }
+        Ok(())
+    }
+
+    /// Fills the given frame, if audio is available. Returns false if no audio is available.
+    ///
+    /// You can wait for `MWCAP_NOTIFY_AUDIO_FRAME_BUFFERED` to ensure audio is available.
+    fn capture_audio_frame(&mut self, frame: &mut AudioCaptureFrame) -> Result<bool> {
+        frame.inner.dwSyncCode = 0;
+        unsafe {
+            if sys::MWCaptureAudioFrame(self.handle(), &mut frame.inner as _)
+                != sys::_MW_RESULT__MW_SUCCEEDED
+            {
+                whatever!("unable to capture audio frame");
+            }
+        }
+        Ok(frame.inner.dwSyncCode != 0)
+    }
+}

--- a/src/pro_eco_capture_family.rs
+++ b/src/pro_eco_capture_family.rs
@@ -63,12 +63,11 @@ pub trait ProEcoCaptureFamily: UniversalCaptureFamily {
     fn capture_audio_frame(&mut self, frame: &mut AudioCaptureFrame) -> Result<bool> {
         frame.inner.dwSyncCode = 0;
         unsafe {
-            if sys::MWCaptureAudioFrame(self.handle(), &mut frame.inner as _)
-                != sys::_MW_RESULT__MW_SUCCEEDED
-            {
-                whatever!("unable to capture audio frame");
+            match sys::MWCaptureAudioFrame(self.handle(), &mut frame.inner as _) {
+                sys::_MW_RESULT__MW_SUCCEEDED => Ok(frame.inner.dwSyncCode != 0),
+                sys::_MW_RESULT__MW_ENODATA => Ok(false),
+                _ => whatever!("unable to capture audio frame"),
             }
         }
-        Ok(frame.inner.dwSyncCode != 0)
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,5 @@
 use super::sys;
+use bitflags::bitflags;
 use std::{ffi::CStr, os::raw::c_char, time::Duration};
 
 fn bytes_to_cstr(bytes: &[c_char]) -> &CStr {
@@ -245,5 +246,29 @@ impl AudioCaptureFrame {
 impl From<sys::_MWCAP_AUDIO_CAPTURE_FRAME> for AudioCaptureFrame {
     fn from(frame: sys::_MWCAP_AUDIO_CAPTURE_FRAME) -> Self {
         AudioCaptureFrame { inner: frame }
+    }
+}
+
+bitflags! {
+    pub struct NotifyEvents: u32 {
+        const INPUT_SORUCE_START_SCAN = 1;
+        const INPUT_SORUCE_STOP_SCAN = 2;
+        const INPUT_SORUCE_SCAN_CHANGE = 3;
+        const VIDEO_INPUT_SOURCE_CHANGE = 4;
+        const AUDIO_INPUT_SOURCE_CHANGE = 8;
+        const INPUT_SPECIFIC_CHANGE = 16;
+        const VIDEO_SIGNAL_CHANGE = 32;
+        const AUDIO_SIGNAL_CHANGE = 64;
+        const VIDEO_FIELD_BUFFERING = 128;
+        const VIDEO_FRAME_BUFFERING = 256;
+        const VIDEO_FIELD_BUFFERED = 512;
+        const VIDEO_FRAME_BUFFERED = 1024;
+        const VIDEO_SMPTE_TIME_CODE = 2048;
+        const AUDIO_FRAME_BUFFERED = 4096;
+        const AUDIO_INPUT_RESET = 8192;
+        const VIDEO_SAMPLING_PHASE_CHANGE = 16384;
+        const LOOP_THROUGH_CHANGED = 32768;
+        const LOOP_THROUGH_EDID_CHANGED = 65536;
+        const NEW_SDI_ANC_PACKET = 131072;
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -87,6 +87,34 @@ impl From<sys::MWCAP_VIDEO_SIGNAL_STATE> for VideoSignalState {
     }
 }
 
+pub struct AudioSignalStatus {
+    inner: sys::MWCAP_AUDIO_SIGNAL_STATUS,
+}
+
+impl AudioSignalStatus {
+    pub fn is_lpcm(&self) -> bool {
+        self.inner.bLPCM != 0
+    }
+
+    pub fn channel_count(&self) -> u32 {
+        self.inner.wChannelValid.count_ones() * 2
+    }
+
+    pub fn bits_per_sample(&self) -> u8 {
+        self.inner.cBitsPerSample
+    }
+
+    pub fn sample_rate(&self) -> u32 {
+        self.inner.dwSampleRate
+    }
+}
+
+impl From<sys::MWCAP_AUDIO_SIGNAL_STATUS> for AudioSignalStatus {
+    fn from(status: sys::MWCAP_AUDIO_SIGNAL_STATUS) -> Self {
+        AudioSignalStatus { inner: status }
+    }
+}
+
 pub struct VideoSignalStatus {
     inner: sys::MWCAP_VIDEO_SIGNAL_STATUS,
 }
@@ -169,5 +197,53 @@ impl EcoVideoCaptureStatus {
 
     pub fn timestamp(&self) -> Duration {
         Duration::from_nanos(100 * self.status.llTimestamp as u64)
+    }
+}
+
+pub struct AudioCaptureFrame {
+    pub(crate) inner: sys::_MWCAP_AUDIO_CAPTURE_FRAME,
+}
+
+impl Default for AudioCaptureFrame {
+    fn default() -> Self {
+        Self {
+            inner: sys::_MWCAP_AUDIO_CAPTURE_FRAME {
+                iFrame: 0,
+                dwReserved: 0,
+                dwSyncCode: 0,
+                cFrameCount: 0,
+                llTimestamp: 0,
+                adwSamples: [0; (sys::MWCAP_AUDIO_SAMPLES_PER_FRAME
+                    * sys::MWCAP_AUDIO_MAX_NUM_CHANNELS) as _],
+            },
+        }
+    }
+}
+
+// In the future, this can be replaced with `ptr.is_aligned()`.
+fn is_aligned<T>(ptr: *const T) -> bool {
+    ptr.align_offset(std::mem::align_of::<T>()) == 0
+}
+
+impl AudioCaptureFrame {
+    /// For LPCM, the channel order is 0L, 1L, 2L, 3L, 0R, 1R, 2R, 3R.
+    pub fn samples(&self) -> &[u32] {
+        // We have to do this in a slightly round-about way to appease the compiler, which
+        // otherwise complains about the possibility of `adwSamples` being unaligned (even though
+        // it always is).
+        let ptr = std::ptr::addr_of!(self.inner.adwSamples);
+        // Proof that our alignment is fine:
+        assert!(is_aligned(ptr));
+        unsafe { (*ptr).as_slice() }
+    }
+
+    pub fn timestamp(&self) -> Duration {
+        Duration::from_nanos(100 * self.inner.llTimestamp as u64)
+    }
+}
+
+impl From<sys::_MWCAP_AUDIO_CAPTURE_FRAME> for AudioCaptureFrame {
+    fn from(frame: sys::_MWCAP_AUDIO_CAPTURE_FRAME) -> Self {
+        AudioCaptureFrame { inner: frame }
     }
 }

--- a/src/universal_capture_family.rs
+++ b/src/universal_capture_family.rs
@@ -1,0 +1,33 @@
+use super::{sys, AudioSignalStatus, ChannelInfo, Result, VideoSignalStatus};
+use snafu::prelude::*;
+use std::{ffi::c_void, mem::MaybeUninit};
+
+pub trait UniversalCaptureFamily {
+    fn handle(&self) -> *mut c_void;
+
+    fn info(&self) -> &ChannelInfo;
+
+    fn get_audio_signal_status(&self) -> Result<AudioSignalStatus> {
+        let mut status = MaybeUninit::uninit();
+        unsafe {
+            if sys::MWGetAudioSignalStatus(self.handle(), status.as_mut_ptr())
+                != sys::_MW_RESULT__MW_SUCCEEDED
+            {
+                whatever!("unable to get audio signal status");
+            }
+            Ok(status.assume_init().into())
+        }
+    }
+
+    fn get_video_signal_status(&self) -> Result<VideoSignalStatus> {
+        let mut status = MaybeUninit::uninit();
+        unsafe {
+            if sys::MWGetVideoSignalStatus(self.handle(), status.as_mut_ptr())
+                != sys::_MW_RESULT__MW_SUCCEEDED
+            {
+                whatever!("unable to get video signal status");
+            }
+            Ok(status.assume_init().into())
+        }
+    }
+}

--- a/src/universal_capture_family.rs
+++ b/src/universal_capture_family.rs
@@ -2,7 +2,9 @@ use super::{sys, AudioSignalStatus, ChannelInfo, Result, VideoSignalStatus};
 use snafu::prelude::*;
 use std::{ffi::c_void, mem::MaybeUninit};
 
-pub trait UniversalCaptureFamily {
+/// # Safety
+/// The pointers returned by implementations of this trait must be valid.
+pub unsafe trait UniversalCaptureFamilyChannel {
     fn handle(&self) -> *mut c_void;
 
     fn info(&self) -> &ChannelInfo;


### PR DESCRIPTION
This PR:

- Adds support for audio capture, which works pretty similarly to video capture.
- Adds support for a `no-deps` feature which will avoid requiring or linking with v4l2, udev, and asound by building in stub versions of those libraries.
- Splits lib.rs up into several files.

The refactors make it a bit hard to see the changes. I'll comment on the important bits.

With this, the crate should be feature complete for our needs. Unless something ends up being off, this should be my last PR here.